### PR TITLE
Fix Cameca's pixel coding by rolling the data.

### DIFF
--- a/openformat/mims.py
+++ b/openformat/mims.py
@@ -2,6 +2,8 @@ import logging
 import os
 import struct
 
+import numpy as np
+
 from .util import Structure, from_buffer
 
 
@@ -19,7 +21,7 @@ ANALYSIS_TYPES = {
 }
 
 
-def load_mims(filename, byte_order=None):
+def load_mims(filename, byte_order=None, roll_data=True):
     """
     Load a multi-isotope imaging mass spectrometry (MIMS) file.
 
@@ -27,6 +29,11 @@ def load_mims(filename, byte_order=None):
     ----------
     filename : str
         path to the MIMS file
+    byte_order : str
+        byte order of the encoded binary data
+    roll_data : bool
+        whether to roll image data along the last two dimenions. Rolling the image fixes an issue
+        with Cameca's encoding of pixel positions.
 
     Returns
     -------
@@ -74,6 +81,8 @@ def load_mims(filename, byte_order=None):
                 f'{mims.header_image.w}, {mims.header_image.h}]'
 
             mims['data'] = from_buffer(fmt, fp, byte_order)
+            if roll_data:
+                mims['data'] = np.roll(mims['data'], 1, axis=(2, 3))
         else:
             raise NotImplementedError(f"{analysis_type} is not implemented")
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     install_requires=[
         'numpy>=1.3'
     ],
-    version="0.1.2",
+    version="0.1.3",
     author="Till Hoffmann",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Note the differences at the bottom and right of the images obtained by rolling.

![image](https://user-images.githubusercontent.com/966348/39518880-7a3bb812-4dfc-11e8-8861-fb17449b3f98.png)
![image](https://user-images.githubusercontent.com/966348/39518887-7eb5a088-4dfc-11e8-8522-93307dd5bb99.png)
