### PR TITLE
 Add code to median-filter and align NanoSIMS data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ Dockerfile
 di.yml
 
 .Trash-*/
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,5 @@ playground/
 dev-requirements.txt
 Dockerfile
 di.yml
+
+.Trash-*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 cache: pip
 install:
 - pip install --upgrade pip setuptools whell
-- pip install --only-binary=numpy,scipy -r requirements.txt
+- pip install --only-binary=scipy -r requirements.txt
 - pip install -e .
 script:
 - make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
 - '3.6'
 cache: pip
 install:
-- pip install --upgrade pip setuptools whell
+- pip install --upgrade pip setuptools wheel
 - pip install --only-binary=scipy -r requirements.txt
 - pip install -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
 - '3.6'
 cache: pip
 install:
-- pip install --upgrade pip
-- pip install -r requirements.txt
+- pip install --upgrade pip setuptools whell
+- pip install --only-binary=numpy,scipy -r requirements.txt
 - pip install -e .
 script:
 - make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '3.6'
 cache: pip
 install:
+- pip install --upgrade pip
 - pip install -r requirements.txt
 - pip install -e .
 script:

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@
 tests : code_tests
 
 code_tests :
-	py.test --cov openformat --cov-fail-under=100 --cov-report=term-missing --cov-report=html
+	py.test --cov openformat --cov-fail-under=100 --cov-report=term-missing --cov-report=html -v

--- a/openformat/mims.py
+++ b/openformat/mims.py
@@ -954,7 +954,7 @@ class Anal_param_nano_bis(Structure):
         assert self.pszNomStruct.startswith(self.__class__.__name__)
 
 
-def remove_correlated_noise(data, kernel_size=3, outlier_factor=3, min_count=1, num_outliers=5):
+def remove_correlated_noise(data, num_outliers, kernel_size=3, outlier_factor=3, min_count=1):
     """
     Remove correlated noise from nanoSIMS data.
 
@@ -963,6 +963,9 @@ def remove_correlated_noise(data, kernel_size=3, outlier_factor=3, min_count=1, 
     data : np.ndarray
         data tensor with shape `(n, p, w, h)`, where `n` is the number of frames,
         `p` is the number of detectors, `w` is the width, and `h` is the height
+    num_outliers : int
+        number of times a pixel needs to be labelled as an outlier in different
+        detectors to be considered correlated noise
     kernel_size : int
         size of the kernel used for median filtering
     outlier_factor : float
@@ -971,9 +974,6 @@ def remove_correlated_noise(data, kernel_size=3, outlier_factor=3, min_count=1, 
     min_count : float
         minimum count used to determine the threshold if the median-filtered image
         is smaller
-    num_outliers : int
-        number of times a pixel needs to be labelled as an outlier in different
-        detectors to be considered correlated noise
 
     Returns
     -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest==3.5.1
 pytest-cov==2.5.1
 numpy==1.14.2
-scipy==0.16.1
+scipy
 setuptools>=38.6.0
 twine>=1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pytest==3.5.1
 pytest-cov==2.5.1
 numpy==1.14.2
+scipy==0.16.1
 setuptools>=38.6.0
 twine>=1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest==3.5.1
 pytest-cov==2.5.1
 numpy==1.14.2
-scipy
+scipy==1.0.1
 setuptools>=38.6.0
 twine>=1.11.0

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,10 @@ setup(
     name='openformat',
     packages=find_packages(),
     install_requires=[
-        'numpy>=1.3'
+        'numpy>=1.3',
+        'scipy>=0.7',
     ],
-    version="0.1.3",
+    version="0.2.0",
     author="Till Hoffmann",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_mims.py
+++ b/tests/test_mims.py
@@ -1,5 +1,6 @@
-from openformat.mims import load_mims, remove_correlated_noise, infer_translations, \
-    apply_translations
+import numpy as np
+from openformat.mims import load_mims, remove_hot_pixels, infer_translations, \
+    apply_translations, infer_hot_pixels, apply_mask
 
 FILENAME = 'tests/data/2018_04_25_Cd_AF33_1_ROI3.im'
 
@@ -13,7 +14,14 @@ def test_load_mims():
 def test_filter_align():
     padding = 8
     mims = load_mims(FILENAME)
-    cleaned = remove_correlated_noise(mims.data, 5)
+    cleaned = remove_hot_pixels(mims.data, 5)
     translations = infer_translations(cleaned[:, 0], padding)
     aligned = apply_translations(cleaned, translations, padding)
     assert aligned.shape == cleaned.shape[:2] + (cleaned.shape[2] + 2 * padding,) * 2
+
+def test_apply_mask():
+    mims = load_mims(FILENAME)
+    mask = infer_hot_pixels(mims.data, 5)
+    cleaned = apply_mask(mims.data, mask, -1)
+    for i in range(cleaned.shape[1]):
+        np.testing.assert_equal(cleaned[:, i] == -1, mask)

--- a/tests/test_mims.py
+++ b/tests/test_mims.py
@@ -1,7 +1,19 @@
-from openformat.mims import load_mims
+from openformat.mims import load_mims, remove_correlated_noise, infer_translations, \
+    apply_translations
+
+FILENAME = 'tests/data/2018_04_25_Cd_AF33_1_ROI3.im'
 
 
 def test_load_mims():
-    mims = load_mims('tests/data/2018_04_25_Cd_AF33_1_ROI3.im')
+    mims = load_mims(FILENAME)
     assert len(mims.tab_mass) == mims.mask_im.nb_mass
     assert mims.data.shape[1] == mims.mask_im.nb_mass
+
+
+def test_filter_align():
+    padding = 8
+    mims = load_mims(FILENAME)
+    cleaned = remove_correlated_noise(mims.data)
+    translations = infer_translations(cleaned[:, 0], padding)
+    aligned = apply_translations(cleaned, translations, padding)
+    assert aligned.shape == cleaned.shape[:2] + (cleaned.shape[2] + 2 * padding,) * 2

--- a/tests/test_mims.py
+++ b/tests/test_mims.py
@@ -13,7 +13,7 @@ def test_load_mims():
 def test_filter_align():
     padding = 8
     mims = load_mims(FILENAME)
-    cleaned = remove_correlated_noise(mims.data)
+    cleaned = remove_correlated_noise(mims.data, 5)
     translations = infer_translations(cleaned[:, 0], padding)
     aligned = apply_translations(cleaned, translations, padding)
     assert aligned.shape == cleaned.shape[:2] + (cleaned.shape[2] + 2 * padding,) * 2


### PR DESCRIPTION
NanoSIMS data can be polluted due to
* correlated noise in the different detectors
* minute translations between successive frames due to vibrations

The functions `remove_correlated_noise`, `infer_translations`, and `apply_translations` allow for the partial removal of such noise.